### PR TITLE
Wrf pkg intel and pgi

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -10,29 +10,25 @@ import glob
 class Wrf(AutotoolsPackage):
     """The Weather Research and Forecasting (WRF) Model
     is a next-generation mesoscale numerical weather prediction system designed
-    for both atmospheric research and operational forecasting applications"""
+    for both atmospheric research and operational forecasting applications.
+    """
 
     homepage = "https://www.mmm.ucar.edu/weather-research-and-forecasting-model"
     url      = "http://www2.mmm.ucar.edu/wrf/src/WRFV3.9.1.TAR.gz"
 
     version('4.0', sha256='a5b072492746f96a926badda7e6b44cb0af26695afdd6c029a94de5e1e5eec73')
 
-    variant('build_type',
-            default='dmpar',
+    variant('build_type', default='dmpar',
             values=('serial', 'smpar', 'dmpar', 'dmsm'))
 
-    variant('nesting',
-            default='basic',
-            values=('basic', 'preset', 'vortex')
-           )
+    variant('nesting', default='basic',
+            values=('basic', 'preset', 'vortex'))
 
-    variant('compile_type',
-            default='em_real',
+    variant('compile_type', default='em_real',
             values=('em_real', 'em_quarter_ss', 'em_b_wave', 'em_les',
                     'em_heldsuarez', 'em_tropical_cyclone', 'em_hill2d_x',
                     'em_squall2d_x', 'em_squall2d_y', 'em_grav2d_x',
-                    'em_seabreeze2d_x', 'em_scm_xy')
-           )
+                    'em_seabreeze2d_x', 'em_scm_xy'))
 
     # These patches deal with netcdf & netcdf-fortran being two diff things
     # Patches are based on:
@@ -62,7 +58,7 @@ class Wrf(AutotoolsPackage):
     depends_on('tcsh', type=('build'))
     # time is not installed on all systems b/c bash provides it
     # this fixes that for csh install scripts
-    depends_on('time', type=('build')) 
+    depends_on('time', type=('build'))
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
@@ -74,6 +70,15 @@ class Wrf(AutotoolsPackage):
         # This gets used via the applied patch files
         spack_env.set('NETCDFF', self.spec['netcdf-fortran'].prefix)
 
+        #ss = self.spec
+        #print(dir(ss.compiler))
+        #import pdb; pdb.set_trace()
+        spack_env.set('SCC', self.compiler.cc)
+        spack_env.set('SFC', self.compiler.fc)
+
+        spack_env.set('SCC', self.compiler.cc)
+        spack_env.set('SFC', self.compiler.fc)
+
     def patch(self):
         # Let's not assume csh is intalled in bin
         files = glob.glob('*.csh')
@@ -82,12 +87,35 @@ class Wrf(AutotoolsPackage):
         filter_file('^#!/bin/csh', '#!/usr/bin/env csh', *files)
 
     def configure(self, spec, prefix):
-        if spec.variants['build_type'].value == 'dmpar':
-            build_type_value = '34'
-        if spec.variants['nesting'].value == 'basic':
-            nesting_value = '1'
+        build_opts = {"gcc":   {"serial": '32',
+                                "smpar":  '33',
+                                "dmpar":  '34',
+                                "dmsm":   '35'},
+                      "intel": {"serial": '13',
+                                "smpar":  '14',
+                                "dmpar":  '15',
+                                "dmsm":   '16'},
+                      "pgi":   {"serial": '52',
+                                "smpar":  '53',
+                                "dmpar":  '54',
+                                "dmsm":   '55'},
+                      }
 
-        install_answer = [build_type_value + '\n', nesting_value + '\n']
+        nesting_opts = {"basic":  "1",
+                        "preset": "2",
+                        "vortex": "3"}
+
+        try:
+            compiler_opts = build_opts[self.spec.compiler.name]
+        except KeyError:
+            raise InstallError("Compiler not recognized nor supported.")
+
+        # Spack already makes sure that the variant value is part of the set.
+        build_type = compiler_opts[spec.variants['build_type'].value]
+
+        nesting_value = nesting_opts[spec.variants['nesting'].value]
+
+        install_answer = [build_type + '\n', nesting_value + '\n']
         install_answer_input = 'spack-config.in'
         with open(install_answer_input, 'w') as f:
             f.writelines(install_answer)


### PR DESCRIPTION
Add more compiler choices.
Prepend pgi path since pgf90 wasn't found.
Use a tempfile to write the input file to the configure.
Enable the parallel build.

Unfortunately the build with PGI+gfortran fails with:
```
ar ru ../main/libwrflib.a module_driver_constants.o module_domain_type.o module_streams.o module_domain.o  module_integrate.o module_timing.o module_configure.o module_tiles.o module_machine.o module_nesting.o module_wrf_error.o module_state_description.o module_sm.o module_io.o module_comm_dm.o module_comm_dm_0.o module_comm_dm_1.o module_comm_dm_2.o module_comm_dm_3.o module_comm_dm_4.o module_comm_nesting_dm.o module_dm.o module_quilt_outbuf_ops.o module_io_quilt.o module_intermediate_nmm.o module_cpl.o module_cpl_oasis3.o module_clear_halos.o wrf_num_bytes_between.o wrf_shutdown.o wrf_debug.o libmassv.o collect_on_comm.o hires_timer.o clog.o nl_get_0_routines.o nl_get_1_routines.o nl_get_2_routines.o nl_get_3_routines.o nl_get_4_routines.o nl_get_5_routines.o nl_get_6_routines.o nl_get_7_routines.o nl_set_0_routines.o nl_set_1_routines.o nl_set_2_routines.o nl_set_3_routines.o nl_set_4_routines.o nl_set_5_routines.o nl_set_6_routines.o nl_set_7_routines.o  module_alloc_space_0.o module_alloc_space_1.o module_alloc_space_2.o module_alloc_space_3.o module_alloc_space_4.o module_alloc_space_5.o module_alloc_space_6.o module_alloc_space_7.o module_alloc_space_8.o module_alloc_space_9.o
ar: creating ../main/libwrflib.a
ar: module_integrate.o: No such file or directory
make[2]: [framework] Error 1 (ignored)
ranlib ../main/libwrflib.a
ranlib: '../main/libwrflib.a': No such file
make[2]: [framework] Error 1 (ignored)
make[2]: Leaving directory `/dev/shm/spack/stage/root/spack-stage/spack-stage-JexrAm/WRF/frame'
make[2]: Entering directory `/dev/shm/spack/stage/root/spack-stage/spack-stage-JexrAm/WRF/external/io_netcdf'
x=`echo "f77" | awk '{print $1}'` ; export x ; \
if [ $x = "gfortran" ] ; then \
           echo removing external declaration of iargc for gfortran ; \
   /lib/cpp -P -nostdinc -P -traditional-cpp -DUSE_NETCDF4_FEATURES -DWRFIO_NCD_LARGE_FILE_SUPPORT -I/include -I../ioapi_share diffwrf.F90 | sed '/integer *, *external.*iargc/d' > diffwrf.f ;\
        else \
   /lib/cpp -P -nostdinc -P -traditional-cpp -DUSE_NETCDF4_FEATURES -DWRFIO_NCD_LARGE_FILE_SUPPORT -I/include -I../ioapi_share diffwrf.F90 > diffwrf.f ; \
        fi
diffwrf.F90:55:0: fatal error: netcdf.inc: No such file or directory
 #include "netcdf.inc"
 ^
```

Any idea? Should I prepend to CPATH also the include dir of netcdf-fortran?